### PR TITLE
Bugfix/User Lists

### DIFF
--- a/graph/gmodel/models_gen.go
+++ b/graph/gmodel/models_gen.go
@@ -61,7 +61,7 @@ type BranchList struct {
 	ListID    int64     `json:"listId"`
 	List      *List     `json:"list,omitempty"`
 	BranchID  int64     `json:"branchId"`
-	Branch    *Branch   `json:"branch,omitempty" alias:"branch_list_branch"`
+	Branch    *Branch   `json:"branch,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 

--- a/graph/list.graphql
+++ b/graph/list.graphql
@@ -32,7 +32,7 @@ type BranchList {
   listId: ID!
   list: List
   branchId: ID!
-  branch: Branch @goTag(key: "alias", value: "branch_list_branch")
+  branch: Branch
   createdAt: Time!
 }
 


### PR DESCRIPTION
The SQL query that was used to return a user's list, had issues with the way joins work and therefore the resulting data was not accurate at all. This PR fixes it by fetching the `list` as a flat array and then for each item we get `product_list` and `branch_list` manually.