### PR TITLE
perf/Remove Vision API Logo Detection

### DIFF
--- a/services/ai_service.go
+++ b/services/ai_service.go
@@ -72,9 +72,6 @@ func (s Service) GoogleVisionOcrData(ctx context.Context, base64_image []byte) (
 			{
 				Type: visionpb.Feature_TEXT_DETECTION,
 			},
-			{
-				Type: visionpb.Feature_LOGO_DETECTION,
-			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Since we don't use the logo detection feature offered by Vision API we can remove it which will result in slightly faster response times.