### PR TITLE
ft/Store Auth State ID as UUID string

### DIFF
--- a/database/jet/postgres/public/model/auth_state.go
+++ b/database/jet/postgres/public/model/auth_state.go
@@ -12,7 +12,7 @@ import (
 )
 
 type AuthState struct {
-	ID            int64 `sql:"primary_key"`
+	ID            string `sql:"primary_key"`
 	LoggedInAt    time.Time
 	UserID        int64
 	IPAddress     *string

--- a/database/jet/postgres/public/table/auth_state.go
+++ b/database/jet/postgres/public/table/auth_state.go
@@ -17,7 +17,7 @@ type authStateTable struct {
 	postgres.Table
 
 	// Columns
-	ID            postgres.ColumnInteger
+	ID            postgres.ColumnString
 	LoggedInAt    postgres.ColumnTimestampz
 	UserID        postgres.ColumnInteger
 	IPAddress     postgres.ColumnString
@@ -64,7 +64,7 @@ func newAuthStateTable(schemaName, tableName, alias string) *AuthStateTable {
 
 func newAuthStateTableImpl(schemaName, tableName, alias string) authStateTable {
 	var (
-		IDColumn            = postgres.IntegerColumn("id")
+		IDColumn            = postgres.StringColumn("id")
 		LoggedInAtColumn    = postgres.TimestampzColumn("logged_in_at")
 		UserIDColumn        = postgres.IntegerColumn("user_id")
 		IPAddressColumn     = postgres.StringColumn("ip_address")

--- a/database/migrations/1755710293057962_auth_state_id_type_change.sql
+++ b/database/migrations/1755710293057962_auth_state_id_type_change.sql
@@ -1,0 +1,2 @@
+alter table "auth_state"
+alter column "id" type varchar(255) using ("id"::varchar(255));

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -21669,9 +21669,9 @@ func (ec *executionContext) _User_authStateId(ctx context.Context, field graphql
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*int64)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalOID2ᚖint64(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_User_authStateId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21681,7 +21681,7 @@ func (ec *executionContext) fieldContext_User_authStateId(ctx context.Context, f
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil

--- a/graph/gmodel/models_gen.go
+++ b/graph/gmodel/models_gen.go
@@ -514,7 +514,7 @@ type User struct {
 	Active        bool              `json:"active"`
 	AuthPlatform  *AuthPlatformType `json:"authPlatform,omitempty" alias:"auth_state.platform"`
 	AuthDevice    *AuthDeviceType   `json:"authDevice,omitempty" alias:"auth_state.device_type"`
-	AuthStateID   *int64            `json:"authStateId,omitempty" alias:"auth_state.id"`
+	AuthStateID   *string           `json:"authStateId,omitempty" alias:"auth_state.id"`
 	ExpoPushToken *string           `json:"expoPushToken,omitempty" alias:"auth_state.expo_push_token"`
 	Role          UserRole          `json:"role"`
 	AddressID     *int64            `json:"addressId,omitempty"`

--- a/graph/user.graphql
+++ b/graph/user.graphql
@@ -89,7 +89,7 @@ type User {
     @goTag(key: "alias", value: "auth_state.platform")
   authDevice: AuthDeviceType
     @goTag(key: "alias", value: "auth_state.device_type")
-  authStateId: ID @goTag(key: "alias", value: "auth_state.id")
+  authStateId: String @goTag(key: "alias", value: "auth_state.id")
   expoPushToken: String @goTag(key: "alias", value: "auth_state.expo_push_token")
   role: UserRole!
   addressId: ID

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -160,7 +160,7 @@ func TestUser(t *testing.T) {
 					var auth_state model.AuthState
 					qb := table.AuthState.SELECT(table.AuthState.AllColumns).
 						FROM(table.AuthState).
-						WHERE(table.AuthState.ID.EQ(postgres.Int(*user1_auth.User.AuthStateID))).
+						WHERE(table.AuthState.ID.EQ(postgres.String(*user1_auth.User.AuthStateID))).
 						LIMIT(1)
 					if err := qb.QueryContext(ctx, db, &auth_state); err != nil {
 						t.Fatal("could not find auth_state entry", err.Error())

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -184,7 +184,7 @@ func TestUser(t *testing.T) {
 						t.Fatal("auth device is not 'android'")
 					}
 
-					var logins []int
+					var logins []string
 					qb := table.AuthState.SELECT(table.AuthState.ID).
 						FROM(table.AuthState).
 						WHERE(table.AuthState.UserID.EQ(postgres.Int(user1.ID)))


### PR DESCRIPTION
The `auth_state.id` column is currently an auto incremented `BIGSERIAL` type, which can lead to security vulnerabilities in the future. This PR changes the column to `varchar(255)` and updates the `user_service` to generate UUID v4 (which generates a random value), preventing auth state id guessing.