### PR TITLE
ft/Update product nutrition

### DIFF
--- a/graph/resolver/product.resolvers.go
+++ b/graph/resolver/product.resolvers.go
@@ -255,7 +255,17 @@ func (r *queryResolver) MyProductViewHistory(ctx context.Context, paginator gmod
 
 // GetProductNutritionData is the resolver for the getProductNutritionData field.
 func (r *queryResolver) GetProductNutritionData(ctx context.Context, productID int64) (*gmodel.ProductNutrition, error) {
+	product, err := r.Service.FindProductById(ctx, productID)
+	if err != nil {
+		return nil, fmt.Errorf("product does not exist")
+	}
+
 	product_nutrition, err := r.Service.FindProductNutrition(ctx, productID)
+	if err == nil {
+		return &product_nutrition, nil
+	}
+
+	product_nutrition, err = r.Service.ProcessOpenFoodFactsData(ctx, product)
 	if err != nil {
 		return nil, err
 	}

--- a/graph/resolver/product.resolvers.go
+++ b/graph/resolver/product.resolvers.go
@@ -225,11 +225,6 @@ func (r *queryResolver) Product(ctx context.Context, id int64, viewerTrail *gmod
 		}
 		r.Service.AddProductViewer(ctx, product.ID, trail_input)
 	}()
-
-	go func() {
-		ctx := context.Background()
-		r.Service.ProcessOpenFoodFactsData(ctx, product)
-	}()
 	return &product, nil
 }
 


### PR DESCRIPTION
This PR loads the OpenFoodFacts data if our database doesn't have the data yet and then returns this data from the query. In addition, we also remove the go routine function that gets the food facts on every product query.