### PR TITLE
ft/Extract and create product

### DIFF
--- a/graph/generated.go
+++ b/graph/generated.go
@@ -204,6 +204,7 @@ type ComplexityRoot struct {
 		CreateStore                 func(childComplexity int, input gmodel.CreateStore) int
 		DeleteList                  func(childComplexity int, listID int64) int
 		DeleteSearchByID            func(childComplexity int, id int64) int
+		ExtractAndCreateProduct     func(childComplexity int, barcode string, base64Image string) int
 		Logout                      func(childComplexity int) int
 		MarkGroceryListItem         func(childComplexity int, groceryListItemID int64, completed bool) int
 		RegisterExpoPushToken       func(childComplexity int, expoPushToken string) int
@@ -622,6 +623,7 @@ type MutationResolver interface {
 	UpdateProduct(ctx context.Context, id int64, input gmodel.UpdateProduct) (*gmodel.Product, error)
 	SaveProductsFromUPCItemDb(ctx context.Context, input gmodel.SaveExternalProductInput) (*gmodel.SearchResult, error)
 	UpdateProductNutritionData(ctx context.Context, productID int64) (*gmodel.ProductNutrition, error)
+	ExtractAndCreateProduct(ctx context.Context, barcode string, base64Image string) (*gmodel.Product, error)
 	DeleteSearchByID(ctx context.Context, id int64) (bool, error)
 	ClearSearchHistory(ctx context.Context) (bool, error)
 	CreateStore(ctx context.Context, input gmodel.CreateStore) (*gmodel.Store, error)
@@ -1545,6 +1547,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteSearchByID(childComplexity, args["id"].(int64)), true
+
+	case "Mutation.extractAndCreateProduct":
+		if e.complexity.Mutation.ExtractAndCreateProduct == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_extractAndCreateProduct_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ExtractAndCreateProduct(childComplexity, args["barcode"].(string), args["base64Image"].(string)), true
 
 	case "Mutation.logout":
 		if e.complexity.Mutation.Logout == nil {
@@ -4449,6 +4463,30 @@ func (ec *executionContext) field_Mutation_deleteSearchById_args(ctx context.Con
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_extractAndCreateProduct_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["barcode"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("barcode"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["barcode"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["base64Image"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("base64Image"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["base64Image"] = arg1
 	return args, nil
 }
 
@@ -12049,6 +12087,135 @@ func (ec *executionContext) fieldContext_Mutation_updateProductNutritionData(ctx
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_updateProductNutritionData_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_extractAndCreateProduct(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_extractAndCreateProduct(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().ExtractAndCreateProduct(rctx, fc.Args["barcode"].(string), fc.Args["base64Image"].(string))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.IsAuthenticated == nil {
+				return nil, errors.New("directive isAuthenticated is not implemented")
+			}
+			return ec.directives.IsAuthenticated(ctx, nil, directive0, nil)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*gmodel.Product); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/pricetra/api/graph/gmodel.Product`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*gmodel.Product)
+	fc.Result = res
+	return ec.marshalNProduct2ᚖgithubᚗcomᚋpricetraᚋapiᚋgraphᚋgmodelᚐProduct(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_extractAndCreateProduct(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Product_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Product_name(ctx, field)
+			case "image":
+				return ec.fieldContext_Product_image(ctx, field)
+			case "description":
+				return ec.fieldContext_Product_description(ctx, field)
+			case "url":
+				return ec.fieldContext_Product_url(ctx, field)
+			case "brand":
+				return ec.fieldContext_Product_brand(ctx, field)
+			case "code":
+				return ec.fieldContext_Product_code(ctx, field)
+			case "color":
+				return ec.fieldContext_Product_color(ctx, field)
+			case "model":
+				return ec.fieldContext_Product_model(ctx, field)
+			case "categoryId":
+				return ec.fieldContext_Product_categoryId(ctx, field)
+			case "category":
+				return ec.fieldContext_Product_category(ctx, field)
+			case "stock":
+				return ec.fieldContext_Product_stock(ctx, field)
+			case "weightValue":
+				return ec.fieldContext_Product_weightValue(ctx, field)
+			case "weightType":
+				return ec.fieldContext_Product_weightType(ctx, field)
+			case "quantityValue":
+				return ec.fieldContext_Product_quantityValue(ctx, field)
+			case "quantityType":
+				return ec.fieldContext_Product_quantityType(ctx, field)
+			case "lowestRecordedPrice":
+				return ec.fieldContext_Product_lowestRecordedPrice(ctx, field)
+			case "highestRecordedPrice":
+				return ec.fieldContext_Product_highestRecordedPrice(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Product_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Product_updatedAt(ctx, field)
+			case "createdById":
+				return ec.fieldContext_Product_createdById(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_Product_createdBy(ctx, field)
+			case "updatedById":
+				return ec.fieldContext_Product_updatedById(ctx, field)
+			case "updatedBy":
+				return ec.fieldContext_Product_updatedBy(ctx, field)
+			case "productList":
+				return ec.fieldContext_Product_productList(ctx, field)
+			case "views":
+				return ec.fieldContext_Product_views(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Product", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_extractAndCreateProduct_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -32450,6 +32617,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "updateProductNutritionData":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateProductNutritionData(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "extractAndCreateProduct":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_extractAndCreateProduct(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/graph/product.graphql
+++ b/graph/product.graphql
@@ -21,6 +21,7 @@ extend type Mutation {
     @isAuthenticated(role: "SUPER_ADMIN")
   updateProductNutritionData(productId: ID!): ProductNutrition!
     @isAuthenticated(role: "CONTRIBUTOR")
+  extractAndCreateProduct(barcode: String!, base64Image: String!): Product! @isAuthenticated
 }
 
 type PaginatedProducts {

--- a/graph/resolver/product.resolvers.go
+++ b/graph/resolver/product.resolvers.go
@@ -25,23 +25,21 @@ func (r *mutationResolver) CreateProduct(ctx context.Context, input gmodel.Creat
 		return nil, err
 	}
 
-	go func ()  {
-		// upload image file to CDN
-		upload_params := uploader.UploadParams{
-			PublicID: product.Code,
-			Tags:     []string{"PRODUCT"},
-		}
-		if input.ImageFile != nil {
-			r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
-		} else if input.ImageBase64 != nil {
-			r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
-		} else if input.ImageURL != nil {
-			r.Service.ImageUrlUpload(ctx, *input.ImageURL, upload_params)
-		}
+	// upload image file to CDN
+	upload_params := uploader.UploadParams{
+		PublicID: product.Code,
+		Tags:     []string{"PRODUCT"},
+	}
+	if input.ImageFile != nil {
+		r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
+	} else if input.ImageBase64 != nil {
+		r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
+	} else if input.ImageURL != nil {
+		r.Service.ImageUrlUpload(ctx, *input.ImageURL, upload_params)
+	}
 
-		// handle billing/logging
-		r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Create, product, input, nil)
-	}()
+	// Handle billing
+	r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Create, product, input, nil)
 	return &product, nil
 }
 
@@ -53,24 +51,23 @@ func (r *mutationResolver) UpdateProduct(ctx context.Context, id int64, input gm
 		return nil, err
 	}
 
-	go func() {
-		// upload image file to CDN
-		if input.ImageFile != nil || input.ImageBase64 != nil {
-			r.Service.DeleteImageUpload(ctx, product.Code)
-		}
-		upload_params := uploader.UploadParams{
-			PublicID: product.Code,
-			Tags:     []string{"PRODUCT"},
-		}
-		if input.ImageFile != nil {
-			r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
-		} else if input.ImageBase64 != nil {
-			r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
-		}
-	
-		// handle billing
-		r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Update, product, input, old_product)
-	}()
+	// upload image file to CDN
+	if input.ImageFile != nil || input.ImageBase64 != nil {
+		r.Service.DeleteImageUpload(ctx, product.Code)
+	}
+	upload_params := uploader.UploadParams{
+		PublicID: product.Code,
+		Tags:     []string{"PRODUCT"},
+	}
+	if input.ImageFile != nil {
+		r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
+	} else if input.ImageBase64 != nil {
+		r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
+	}
+
+	// Handle billing
+	// TODO: fetch old product info
+	r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Update, product, input, old_product)
 	return &product, nil
 }
 

--- a/graph/resolver/product.resolvers.go
+++ b/graph/resolver/product.resolvers.go
@@ -95,6 +95,29 @@ func (r *mutationResolver) UpdateProductNutritionData(ctx context.Context, produ
 	return &product_nutrition, nil
 }
 
+// ExtractAndCreateProduct is the resolver for the extractAndCreateProduct field.
+func (r *mutationResolver) ExtractAndCreateProduct(ctx context.Context, barcode string, base64Image string) (*gmodel.Product, error) {
+	if p, err := r.Service.FindProductWithCode(ctx, barcode); err == nil {
+		return &p, nil
+	}
+
+	user := r.Service.GetAuthUserFromContext(ctx)
+	fields, err := r.Service.ExtractProductTextFromBase64Image(ctx, user, base64Image)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.CreateProduct(ctx, gmodel.CreateProduct{
+		Code: barcode,
+		Brand: fields.Brand,
+		Name: fields.Name,
+		Weight: fields.Weight,
+		QuantityValue: fields.Quantity,
+		CategoryID: *fields.CategoryID,
+		ImageBase64: &base64Image,
+	})
+}
+
 // BarcodeScan is the resolver for the barcodeScan field.
 func (r *queryResolver) BarcodeScan(ctx context.Context, barcode string, searchMode *bool) (*gmodel.Product, error) {
 	user := r.Service.GetAuthUserFromContext(ctx)

--- a/graph/resolver/product.resolvers.go
+++ b/graph/resolver/product.resolvers.go
@@ -25,21 +25,23 @@ func (r *mutationResolver) CreateProduct(ctx context.Context, input gmodel.Creat
 		return nil, err
 	}
 
-	// upload image file to CDN
-	upload_params := uploader.UploadParams{
-		PublicID: product.Code,
-		Tags:     []string{"PRODUCT"},
-	}
-	if input.ImageFile != nil {
-		r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
-	} else if input.ImageBase64 != nil {
-		r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
-	} else if input.ImageURL != nil {
-		r.Service.ImageUrlUpload(ctx, *input.ImageURL, upload_params)
-	}
+	go func ()  {
+		// upload image file to CDN
+		upload_params := uploader.UploadParams{
+			PublicID: product.Code,
+			Tags:     []string{"PRODUCT"},
+		}
+		if input.ImageFile != nil {
+			r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
+		} else if input.ImageBase64 != nil {
+			r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
+		} else if input.ImageURL != nil {
+			r.Service.ImageUrlUpload(ctx, *input.ImageURL, upload_params)
+		}
 
-	// Handle billing
-	r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Create, product, input, nil)
+		// handle billing/logging
+		r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Create, product, input, nil)
+	}()
 	return &product, nil
 }
 
@@ -51,23 +53,24 @@ func (r *mutationResolver) UpdateProduct(ctx context.Context, id int64, input gm
 		return nil, err
 	}
 
-	// upload image file to CDN
-	if input.ImageFile != nil || input.ImageBase64 != nil {
-		r.Service.DeleteImageUpload(ctx, product.Code)
-	}
-	upload_params := uploader.UploadParams{
-		PublicID: product.Code,
-		Tags:     []string{"PRODUCT"},
-	}
-	if input.ImageFile != nil {
-		r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
-	} else if input.ImageBase64 != nil {
-		r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
-	}
-
-	// Handle billing
-	// TODO: fetch old product info
-	r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Update, product, input, old_product)
+	go func() {
+		// upload image file to CDN
+		if input.ImageFile != nil || input.ImageBase64 != nil {
+			r.Service.DeleteImageUpload(ctx, product.Code)
+		}
+		upload_params := uploader.UploadParams{
+			PublicID: product.Code,
+			Tags:     []string{"PRODUCT"},
+		}
+		if input.ImageFile != nil {
+			r.Service.GraphImageUpload(ctx, *input.ImageFile, upload_params)
+		} else if input.ImageBase64 != nil {
+			r.Service.Base64ImageUpload(ctx, *input.ImageBase64, upload_params)
+		}
+	
+		// handle billing
+		r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Update, product, input, old_product)
+	}()
 	return &product, nil
 }
 

--- a/graph/resolver/product.resolvers.go
+++ b/graph/resolver/product.resolvers.go
@@ -38,8 +38,11 @@ func (r *mutationResolver) CreateProduct(ctx context.Context, input gmodel.Creat
 		r.Service.ImageUrlUpload(ctx, *input.ImageURL, upload_params)
 	}
 
-	// Handle billing
-	r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Create, product, input, nil)
+	// handle billing
+	go func() {
+		ctx := context.Background()
+		r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Create, product, input, nil)
+	}()
 	return &product, nil
 }
 
@@ -66,8 +69,10 @@ func (r *mutationResolver) UpdateProduct(ctx context.Context, id int64, input gm
 	}
 
 	// Handle billing
-	// TODO: fetch old product info
-	r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Update, product, input, old_product)
+	go func() {
+		ctx := context.Background()
+		r.Service.CreateProductBilling(ctx, user, model.ProductBillingType_Update, product, input, old_product)
+	}()
 	return &product, nil
 }
 

--- a/services/product_service.go
+++ b/services/product_service.go
@@ -614,6 +614,10 @@ func (s Service) ExtractProductTextFromBase64Image(ctx context.Context, user gmo
 		if err == nil {
 			extraction_ob.CategoryID = &category.ID
 			extraction_ob.Category = &category
+		} else {
+			cat, _ := s.FindCategoryById(ctx, 842)
+			extraction_ob.CategoryID = &cat.ID
+			extraction_ob.Category = &cat
 		}
 	}
 


### PR DESCRIPTION
Resolver that extracts image data into `CreateProductInput` and then uses that and the base64 image to create a new product entry. All in a single mutation. This increases performance on the mobile app and also reduces server load/bandwidth since the heavy image is only uploaded once to the backend.